### PR TITLE
[FT] Support string commands in configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "party"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/iamroot99/party"
 readme = "README.md"
-version = "0.1.4"
+version = "0.2.0"
 keywords = ["cli", "automation", "development", "helper"]
 categories = ["command-line-utilities", "development-tools"]
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ This generates a local `party.toml`:
 
 ```toml
 [[tasks]]
-command = ["cargo", "fmt"]
+command = "cargo fmt"
 
 [[tasks]]
-command = ["cargo", "clippy", "--", "-Dwarnings"]
+command = "cargo clippy -- -Dwarnings"
 
 [[tasks]]
-command = ["cargo", "test"]
+command = "cargo test"
 ```
 
 Once the file is ready, invoking `party run` will run your custom party of commands!
@@ -62,18 +62,18 @@ In the example below, the second and third command are independent and have the 
 
 ```toml
 [[tasks]]
-command = ["cargo", "fmt"]
+command = "cargo fmt"
 
 [[tasks]]
-command = ["cargo", "clippy", "--", "-Dwarnings"]
+command = "cargo clippy -- -Dwarnings"
 parallel = true
 
 [[tasks]]
-command = ["cargo", "test"]
+command = "cargo test"
 parallel = true
 
 [[tasks]]
-command = ["cat", "results.txt"]
+command = "cat results.txt"
 ```
 
 The commands that are paralelised in the configuration have a `[P]` tag in `party info`:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ command = "cargo clippy -- -Dwarnings"
 command = "cargo test"
 ```
 
+> [!IMPORTANT]  
+> If using party <= 0.1.4 the syntax for the command is
+> ```toml
+> command = ["command", "arg1", "arg2", "arg3"]
+> ``` 
+
 Once the file is ready, invoking `party run` will run your custom party of commands!
 To run a single party command, use `party run -i [COMMAND_NUMBER]`.
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,12 @@ command = "cargo test"
 ```
 
 > [!IMPORTANT]  
-> If using party <= 0.1.4 the syntax for the command is
+> If using party <= 0.1.4 the syntax for the command is:
 > ```toml
 > command = ["command", "arg1", "arg2", "arg3"]
 > ``` 
+>
+> This is incompatible with party 0.2.0 and above and all `party.toml` files must be updated.
 
 Once the file is ready, invoking `party run` will run your custom party of commands!
 To run a single party command, use `party run -i [COMMAND_NUMBER]`.

--- a/party.toml
+++ b/party.toml
@@ -1,18 +1,18 @@
 [[tasks]]
-command = ["cargo", "fmt"]
+command = "cargo fmt"
 
 [[tasks]]
-command = ["sleep", "5"]
+command = "sleep 5"
 parallel = true
 
 [[tasks]]
-command = ["cargo", "clippy", "--", "-Dwarnings"]
+command = "cargo clippy -- -Dwarnings"
 parallel = true
 
 [[tasks]]
-command = ["cargo", "test"]
+command = "cargo test"
 parallel = true
 
 [[tasks]]
-command = ["sleep", "5"]
+command = "sleep 5"
 parallel = true

--- a/src/cli_commands/init.rs
+++ b/src/cli_commands/init.rs
@@ -11,7 +11,7 @@ use crate::{
     util::{CHECK, DEFAULT_PARTY_CONF},
 };
 
-/// Implementation of `party init
+/// Implementation of `party init`
 pub fn init(init_args: InitArgs) -> anyhow::Result<()> {
     let commands = make_default_commands();
 

--- a/src/party_command.rs
+++ b/src/party_command.rs
@@ -9,37 +9,29 @@ pub struct PartyCommand {
     /// Command to run
     pub command: String,
 
-    /// Command arguments
-    pub args: Vec<String>,
-
     /// Signals if command can be paralelised
     pub is_parallel: bool,
 }
 
 impl PartyCommand {
     /// Create a new PartyCommand
-    pub fn new(command: String, args: Vec<String>, is_parallel: bool) -> Self {
+    pub fn new(command: String, is_parallel: bool) -> Self {
         Self {
             command,
-            args,
             is_parallel,
         }
     }
 }
 
 impl From<Task> for PartyCommand {
-    fn from(mut task: Task) -> Self {
+    fn from(task: Task) -> Self {
         assert!(!task.command.is_empty());
-
-        let command = task.command.remove(0);
-        let args = task.command;
 
         // A task is not parallel by default
         let is_parallel = task.parallel.unwrap_or(false);
 
         Self {
-            command,
-            args,
+            command: task.command,
             is_parallel,
         }
     }
@@ -47,13 +39,7 @@ impl From<Task> for PartyCommand {
 
 impl fmt::Display for PartyCommand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut out = self.command.clone();
-        for arg in &self.args {
-            out += " ";
-            out += arg;
-        }
-
-        write!(f, "{}", out)
+        write!(f, "{}", self.command)
     }
 }
 
@@ -63,15 +49,11 @@ impl fmt::Display for PartyCommand {
 /// - cargo clippy -- -Dwarnings
 /// - cargo test
 pub fn make_default_commands() -> Vec<PartyCommand> {
-    let cargo_fmt = PartyCommand::new("cargo".into(), vec!["fmt".into()], false);
+    let cargo_fmt = PartyCommand::new("cargo fmt".to_string(), false);
 
-    let cargo_clippy = PartyCommand::new(
-        "cargo".into(),
-        vec!["clippy".into(), "--".into(), "-Dwarnings".into()],
-        false,
-    );
+    let cargo_clippy = PartyCommand::new("cargo clippy -- -Dwarnings".to_string(), false);
 
-    let cargo_test = PartyCommand::new("cargo".into(), vec!["test".into()], false);
+    let cargo_test = PartyCommand::new("cargo test".to_string(), false);
 
     vec![cargo_fmt, cargo_clippy, cargo_test]
 }
@@ -88,11 +70,7 @@ mod test {
     #[test]
     fn test_display() {
         // GIVEN
-        let cmd = PartyCommand::new(
-            "cargo".into(),
-            vec!["clippy".into(), "--".into(), "-Dwarnings".into()],
-            false,
-        );
+        let cmd = PartyCommand::new("cargo clippy -- -Dwarnings".to_string(), false);
 
         // WHEN
         let cmd_string = format!("{}", cmd);

--- a/src/runner/command_handler.rs
+++ b/src/runner/command_handler.rs
@@ -12,33 +12,34 @@ use super::run_report::RunReport;
 
 pub fn handle_single_command(
     counter_str: ColoredString,
-    raw_cmd: &PartyCommand,
+    party_cmd: &PartyCommand,
 ) -> anyhow::Result<RunReport> {
-    println!("{} {} {}", HOURGLASS, counter_str, raw_cmd);
+    println!("{} {} {}", HOURGLASS, counter_str, party_cmd);
 
-    let mut command: std::process::Child = Command::new(raw_cmd.command.clone())
-        .args(raw_cmd.args.clone())
+    let mut command: std::process::Child = Command::new("sh")
+        .arg("-c")
+        .arg(&party_cmd.command)
         .spawn()
-        .context(format!("Failed to start task: \"{}\"", raw_cmd))?;
+        .context(format!("Failed to start task: \"{}\"", party_cmd))?;
 
     let output = command
         .wait()
-        .context(format!("Task failed: \"{}\"", raw_cmd))?;
+        .context(format!("Task failed: \"{}\"", party_cmd))?;
 
     if !output.success() {
         match output.code() {
             Some(code) => {
                 let err_msg = make_message_bright_red(&format!(" returned with code {}", code));
-                let full_err_msg = format!("{} {} {} {}", CROSS, counter_str, raw_cmd, err_msg);
+                let full_err_msg = format!("{} {} {} {}", CROSS, counter_str, party_cmd, err_msg);
                 eprintln!("{}", full_err_msg);
 
                 return Ok(RunReport::new_failed(full_err_msg));
             }
-            None => bail!("Task \"{}\" terminated with a signal", raw_cmd),
+            None => bail!("Task \"{}\" terminated with a signal", party_cmd),
         }
     }
 
-    let message = format!("{} {} {}", CHECK, counter_str, raw_cmd);
+    let message = format!("{} {} {}", CHECK, counter_str, party_cmd);
     println!("{}", message);
 
     Ok(RunReport::new_success(message))

--- a/src/runner/command_handler.rs
+++ b/src/runner/command_handler.rs
@@ -10,6 +10,7 @@ use crate::{
 
 use super::run_report::RunReport;
 
+/// Runs a single command
 pub fn handle_single_command(
     counter_str: ColoredString,
     party_cmd: &PartyCommand,

--- a/src/runner/run_report.rs
+++ b/src/runner/run_report.rs
@@ -1,3 +1,5 @@
+//! Report for a command run
+
 pub struct RunReport {
     pub message: String,
     pub success: bool,

--- a/src/schdeuler.rs
+++ b/src/schdeuler.rs
@@ -45,11 +45,11 @@ pub mod test {
     use super::schedule_commands;
 
     fn parallel_command() -> PartyCommand {
-        PartyCommand::new("".into(), vec![], true)
+        PartyCommand::new("".to_string(), true)
     }
 
     fn sequential_command() -> PartyCommand {
-        PartyCommand::new("".into(), vec![], false)
+        PartyCommand::new("".to_string(), false)
     }
 
     #[test]


### PR DESCRIPTION
## Description

* Accepts commands in `party.toml` as strings instead of arrays of strings.

**Before**:
```toml
[[tasks]]
command = ["cargo", "clippy", "--", "-Dwarnings"]
```

**After**:
```
[[tasks]]
command = "cargo clippy -- -Dwarnings"
parallel = true
```

**NOTE: This is a breaking change. The old format will no longer be supported!**